### PR TITLE
chore[#2]: JPA & Querydsl 사용환경 세팅

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,8 +32,29 @@ dependencies {
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+    /* QueryDSL */
+    var queryDslVersion = "5.1.0"
+    implementation "com.querydsl:querydsl-jpa:${queryDslVersion}:jakarta"
+    annotationProcessor "com.querydsl:querydsl-apt:${queryDslVersion}:jakarta"
+    annotationProcessor "jakarta.annotation:jakarta.annotation-api"
+    annotationProcessor "jakarta.persistence:jakarta.persistence-api"
 }
 
 tasks.named('test') {
 	useJUnitPlatform()
+}
+
+/* QueryDSL 생성 파일 경로 설정 */
+def generatedDir = layout.buildDirectory.dir('generated/querydsl')
+
+sourceSets {
+    main.java.srcDirs += [ generatedDir ]
+}
+
+tasks.withType(JavaCompile).configureEach {
+    options.getGeneratedSourceOutputDirectory().set(generatedDir)
+}
+
+clean.doLast {
+    project.delete(generatedDir)
 }


### PR DESCRIPTION
querydsl 5.1.0 버전에서 취약점이 보고되었다는 경고가 나타나는 상황
-> maven repository 기준 5.1.0이 최신 버전으로 확인되고 있음
-> 추후 버전 업데이트 확인해보고 반영하는 것으로 결정