### PR TITLE
chore[#3]: 양방향 연관관계 Entity 구성 (BasicMember, BasicPost)

### DIFF
--- a/src/main/java/com/ktb/howard/ktb_community_server/basic/entity/BasicMember.java
+++ b/src/main/java/com/ktb/howard/ktb_community_server/basic/entity/BasicMember.java
@@ -1,0 +1,57 @@
+package com.ktb.howard.ktb_community_server.basic.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+@Entity
+@Table(name = "basic_member")
+public class BasicMember {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "basic_member_id")
+    private Long id;
+
+    @Column(name = "email", length = 254, nullable = false, unique = true)
+    private String email;
+
+    @Column(name = "password", nullable = false)
+    private String password;
+
+    @Column(name = "nickname", length = 10, nullable = false, unique = true)
+    private String nickname;
+
+    @Column(name = "profile_image_url", length = 1024)
+    private String profileImageUrl;
+
+    @OneToMany(mappedBy = "writer")
+    private List<BasicPost> posts = new ArrayList<>();
+
+    @CreationTimestamp
+    @Column(name = "created_at", nullable = false)
+    private LocalDateTime createdAt;
+
+    @UpdateTimestamp
+    @Column(name = "modified_at")
+    private LocalDateTime modifiedAt;
+
+    @Builder
+    public BasicMember(String email, String password, String nickname, String profileImageUrl) {
+        this.email = email;
+        this.password = password;
+        this.nickname = nickname;
+        this.profileImageUrl = profileImageUrl;
+    }
+
+}

--- a/src/main/java/com/ktb/howard/ktb_community_server/basic/entity/BasicPost.java
+++ b/src/main/java/com/ktb/howard/ktb_community_server/basic/entity/BasicPost.java
@@ -1,0 +1,50 @@
+package com.ktb.howard.ktb_community_server.basic.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+
+import java.time.LocalDateTime;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+@Entity
+@Table(name = "basic_post")
+public class BasicPost {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "basic_post_id")
+    private Long id;
+
+    @Column(name = "title", length = 100, nullable = false)
+    private String title;
+
+    @Lob
+    @Column(name = "content", nullable = false, columnDefinition = "LONGTEXT")
+    private String content;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "basic_member_id")
+    private BasicMember writer;
+
+    @CreationTimestamp
+    @Column(name = "created_at", nullable = false)
+    private LocalDateTime createdAt;
+
+    @UpdateTimestamp
+    @Column(name = "modified_at")
+    private LocalDateTime modifiedAt;
+
+    @Builder
+    public BasicPost(String title, String content, BasicMember writer) {
+        this.title = title;
+        this.content = content;
+        this.writer = writer;
+    }
+
+}


### PR DESCRIPTION
과제 수행에 사용하기 위한 다음 2개의 양방향 연관관계 Entity 생성완료

BasicMember
BasicPost
-> 둘은 서로 회원과 게시글의 관계로 1:N 관계를 구성함