### PR TITLE
chore[#5]: Community 주요 Entity 작성

### DIFF
--- a/src/main/java/com/ktb/howard/ktb_community_server/BaseEntity.java
+++ b/src/main/java/com/ktb/howard/ktb_community_server/BaseEntity.java
@@ -1,0 +1,29 @@
+package com.ktb.howard.ktb_community_server;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public class BaseEntity {
+
+    @CreationTimestamp
+    @Column(name = "created_at", nullable = false)
+    private LocalDateTime createdAt;
+
+    @UpdateTimestamp
+    @Column(name = "modified_at")
+    private LocalDateTime modifiedAt;
+
+    @Column(name = "deleted_at")
+    private LocalDateTime deletedAt;
+
+}

--- a/src/main/java/com/ktb/howard/ktb_community_server/KtbCommunityServerApplication.java
+++ b/src/main/java/com/ktb/howard/ktb_community_server/KtbCommunityServerApplication.java
@@ -2,7 +2,9 @@ package com.ktb.howard.ktb_community_server;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
+@EnableJpaAuditing
 @SpringBootApplication
 public class KtbCommunityServerApplication {
 

--- a/src/main/java/com/ktb/howard/ktb_community_server/comment/domain/Comment.java
+++ b/src/main/java/com/ktb/howard/ktb_community_server/comment/domain/Comment.java
@@ -1,0 +1,57 @@
+package com.ktb.howard.ktb_community_server.comment.domain;
+
+import com.ktb.howard.ktb_community_server.BaseEntity;
+import com.ktb.howard.ktb_community_server.member.domain.Member;
+import com.ktb.howard.ktb_community_server.post.domain.Post;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.SQLRestriction;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+@Entity
+@Table(
+        name = "comment",
+        indexes = @Index(
+                name = "idx_comment_post_id_deleted_at_created_at",
+                columnList = "post_id, deleted_at, created_at"
+        )
+)
+@SQLDelete(sql = "UPDATE comment SET deleted_at = NOW() WHERE comment_id = ?")
+@SQLRestriction("deleted_at is NULL")
+public class Comment extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "comment_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "post_id")
+    private Post post;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id")
+    private Member member;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "parent_comment_id")
+    private Comment parentComment;
+
+    @Lob
+    @Column(name = "content", nullable = false, columnDefinition = "TEXT")
+    private String content;
+
+    @Builder
+    public Comment(Post post, Member member, Comment parentComment, String content) {
+        this.post = post;
+        this.member = member;
+        this.parentComment = parentComment;
+        this.content = content;
+    }
+
+}

--- a/src/main/java/com/ktb/howard/ktb_community_server/like_log/domain/LikeLogType.java
+++ b/src/main/java/com/ktb/howard/ktb_community_server/like_log/domain/LikeLogType.java
@@ -1,0 +1,5 @@
+package com.ktb.howard.ktb_community_server.like_log.domain;
+
+public enum LikeLogType {
+    LIKE, CANCEL
+}

--- a/src/main/java/com/ktb/howard/ktb_community_server/like_log/domain/likeLog.java
+++ b/src/main/java/com/ktb/howard/ktb_community_server/like_log/domain/likeLog.java
@@ -1,0 +1,53 @@
+package com.ktb.howard.ktb_community_server.like_log.domain;
+
+import com.ktb.howard.ktb_community_server.member.domain.Member;
+import com.ktb.howard.ktb_community_server.post.domain.Post;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.CreationTimestamp;
+
+import java.time.LocalDateTime;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+@Entity
+@Table(
+        name = "like_log",
+        indexes = @Index(
+                name = "idx_like_log_post_member_type_created",
+                columnList = "post_id, member_id, type, created_at"
+        )
+)
+public class likeLog {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "like_log_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id")
+    private Member member;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "post_id")
+    private Post post;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "type", nullable = false)
+    private LikeLogType type = LikeLogType.LIKE;
+
+    @CreationTimestamp
+    @Column(name = "created_at")
+    private LocalDateTime createdAt;
+
+    @Builder
+    public likeLog(Member member, Post post) {
+        this.member = member;
+        this.post = post;
+    }
+
+}

--- a/src/main/java/com/ktb/howard/ktb_community_server/member/domain/Member.java
+++ b/src/main/java/com/ktb/howard/ktb_community_server/member/domain/Member.java
@@ -1,0 +1,45 @@
+package com.ktb.howard.ktb_community_server.member.domain;
+
+import com.ktb.howard.ktb_community_server.BaseEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.SQLRestriction;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+@Entity
+@Table(name = "member")
+@SQLDelete(sql = "UPDATE member SET deleted_at = NOW() WHERE member_id = ?")
+@SQLRestriction("deleted_at is NULL")
+public class Member extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "member_id")
+    private Integer id;
+
+    @Column(name = "email", nullable = false, unique = true)
+    private String email;
+
+    @Column(name = "password", nullable = false)
+    private String password;
+
+    @Column(name = "nickname", nullable = false, unique = true)
+    private String nickname;
+
+    @Column(name = "profile_image_url")
+    private String profileImageUrl;
+
+    @Builder
+    public Member(String email, String password, String nickname, String profileImageUrl) {
+        this.email = email;
+        this.password = password;
+        this.nickname = nickname;
+        this.profileImageUrl = profileImageUrl;
+    }
+
+}

--- a/src/main/java/com/ktb/howard/ktb_community_server/post/domain/Post.java
+++ b/src/main/java/com/ktb/howard/ktb_community_server/post/domain/Post.java
@@ -1,0 +1,55 @@
+package com.ktb.howard.ktb_community_server.post.domain;
+
+import com.ktb.howard.ktb_community_server.BaseEntity;
+import com.ktb.howard.ktb_community_server.member.domain.Member;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.SQLRestriction;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+@Entity
+@SQLDelete(sql = "UPDATE post SET deleted_at = NOW() WHERE post_id = ?")
+@SQLRestriction("deleted_at is NULL")
+public class Post extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "post_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id")
+    private Member writer;
+
+    @Column(name = "title", length = 26, nullable = false)
+    private String title;
+
+    @Lob
+    @Column(name = "content", nullable = false, columnDefinition = "LONGTEXT")
+    private String content;
+
+    @Column(name = "like_count", nullable = false)
+    private Integer likeCount = 0;
+
+    @Column(name = "view_count", nullable = false)
+    private Long viewCount = 0L;
+
+    @Column(name = "comment_count", nullable = false)
+    private Long commentCount = 0L;
+
+    @Builder
+    public Post(Member writer, String title, String content, Integer likeCount, Long viewCount, Long commentCount) {
+        this.writer = writer;
+        this.title = title;
+        this.content = content;
+        this.likeCount = likeCount;
+        this.viewCount = viewCount;
+        this.commentCount = commentCount;
+    }
+
+}

--- a/src/main/java/com/ktb/howard/ktb_community_server/post_image/domain/PostImage.java
+++ b/src/main/java/com/ktb/howard/ktb_community_server/post_image/domain/PostImage.java
@@ -1,0 +1,49 @@
+package com.ktb.howard.ktb_community_server.post_image.domain;
+
+import com.ktb.howard.ktb_community_server.BaseEntity;
+import com.ktb.howard.ktb_community_server.post.domain.Post;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.SQLRestriction;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+@Entity
+@Table(
+        name = "post_image",
+        indexes = @Index(
+                name = "idx_pi_post_id_deleted_at_sequence",
+                columnList = "post_id, deleted_at, sequence"
+        )
+)
+@SQLDelete(sql = "UPDATE post_image SET deleted_at = NOW() WHERE post_image_id = ?")
+@SQLRestriction("deleted_at is NULL")
+public class PostImage extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "post_image_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "post_id")
+    private Post post;
+
+    @Column(name = "image_url")
+    private String imageUrl;
+
+    @Column(name = "sequence")
+    private Integer sequence = 1;
+
+    @Builder
+    public PostImage(Post post, String imageUrl, Integer sequence) {
+        this.post = post;
+        this.imageUrl = imageUrl;
+        this.sequence = sequence;
+    }
+
+}

--- a/src/main/java/com/ktb/howard/ktb_community_server/view_log/domain/ViewLog.java
+++ b/src/main/java/com/ktb/howard/ktb_community_server/view_log/domain/ViewLog.java
@@ -1,0 +1,49 @@
+package com.ktb.howard.ktb_community_server.view_log.domain;
+
+import com.ktb.howard.ktb_community_server.member.domain.Member;
+import com.ktb.howard.ktb_community_server.post.domain.Post;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.CreationTimestamp;
+
+import java.time.LocalDateTime;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+@Entity
+@Table(
+        name = "view_log",
+        indexes = @Index(
+                name = "idx_view_log_post_member_created",
+                columnList = "post_id, member_id, created_at"
+        )
+)
+public class ViewLog {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "view_log_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id")
+    private Member member;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "post_id")
+    private Post post;
+
+    @CreationTimestamp
+    @Column(name = "created_at")
+    private LocalDateTime createdAt;
+
+    @Builder
+    public ViewLog(Member member, Post post) {
+        this.member = member;
+        this.post = post;
+    }
+
+}


### PR DESCRIPTION
Community 시스템에 필요한 다음 6개의 Entity를 작성완료

1. Member
2. Post
3. PostImage
4. Comment
5. LikeLog
6. ViewLog

주의!
-> 현재 단계에서는 DB의 설계와 정확히 매핑되는 Entity 코드를 작성하는 것을 목표로함
-> 각 Entity의 필드 업데이트 메서드 작성 등은 개발 과정에서 필요에 따라 추가하는 것으로
-> 모든 연관관계도 단방향으로 설정 (추후 필요에 따라 양방향으로 변경)