### PR TITLE
chore[#11]: Querydsl 취약점 대응버전으로 변경

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,10 +32,10 @@ dependencies {
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
-    /* QueryDSL */
-    var queryDslVersion = "5.1.0"
-    implementation "com.querydsl:querydsl-jpa:${queryDslVersion}:jakarta"
-    annotationProcessor "com.querydsl:querydsl-apt:${queryDslVersion}:jakarta"
+    /* QueryDSL - 취약점이 패치된 커뮤니티 유지보수 버전으로 변경 */
+    var queryDslVersion = "5.1.1" // 패치된 최신 버전
+    implementation "io.github.openfeign.querydsl:querydsl-jpa:${queryDslVersion}:jakarta" // 그룹 ID 변경
+    annotationProcessor "io.github.openfeign.querydsl:querydsl-apt:${queryDslVersion}:jakarta" // 그룹 ID 변경
     annotationProcessor "jakarta.annotation:jakarta.annotation-api"
     annotationProcessor "jakarta.persistence:jakarta.persistence-api"
 }


### PR DESCRIPTION
io.github.openfeign.querydsl 의 5.1.1 버전으로 교체하여 취약점 문제 해결