### PR TITLE
test[#97]: 댓글(comment) 관련 API URL 설계 잘못된 부분 수정하기

### DIFF
--- a/src/main/java/com/ktb/howard/ktb_community_server/comment/controller/CommentController.java
+++ b/src/main/java/com/ktb/howard/ktb_community_server/comment/controller/CommentController.java
@@ -27,13 +27,14 @@ public class CommentController {
     private final CommentService commentService;
 
     @PreAuthorize("isAuthenticated()")
-    @PostMapping("/comments")
+    @PostMapping("/{postId}/comments")
     public ResponseEntity<CreateCommentResponseDto> createComment(
             @AuthenticationPrincipal CustomUser loginMember,
+            @PathVariable Long postId,
             @Valid @RequestBody CreateCommentRequestDto request
     ) {
         CreateCommentResponseDto response = commentService.createComment(
-                request.postId(),
+                postId,
                 loginMember.getId(),
                 request.parentCommentId(),
                 request.content()

--- a/src/main/java/com/ktb/howard/ktb_community_server/comment/dto/CreateCommentRequestDto.java
+++ b/src/main/java/com/ktb/howard/ktb_community_server/comment/dto/CreateCommentRequestDto.java
@@ -6,9 +6,6 @@ import jakarta.validation.constraints.Positive;
 
 public record CreateCommentRequestDto(
         @Positive
-        @NotNull(message = "postId는 필수값입니다.")
-        Long postId,
-        @Positive
         @NotNull(message = "memberId는 필수값입니다.")
         Integer memberId,
         @Positive


### PR DESCRIPTION
수정 결과
적용 대상이었던 다음 4개의 API 중에서 댓글 생성 API에만 해당 설계를 적용했고, 나머지 3개에는 적용하지 않음.
-> 나머지 3개의 경우 해당 패턴을 적용하면 오히려 불필요한 비용이나 무의미한 코드를 발생시킨다는 점을 확인함.

댓글 생성 : POST /posts/comments -> POST /posts/{postId}/comments
대댓글 조회 : GET /posts/comments/{commentId}
댓글 수정 : PATCH /posts/comments/{commentId}
댓글 삭제 : DELETE /posts/comments/{commentId}