### PR TITLE
feat,test[#105]: 게시글 세부정보 조회 API 응답에 좋아요 여부를 의미하는 flag 추가하기

### DIFF
--- a/src/main/java/com/ktb/howard/ktb_community_server/post/dto/PostDetailDto.java
+++ b/src/main/java/com/ktb/howard/ktb_community_server/post/dto/PostDetailDto.java
@@ -29,6 +29,8 @@ public class PostDetailDto {
 
     private Long commentCount;
 
+    private Boolean isLiked;
+
     private LocalDateTime createdAt;
 
 }

--- a/src/main/java/com/ktb/howard/ktb_community_server/post/dto/PostDetailWithLikeInfoDto.java
+++ b/src/main/java/com/ktb/howard/ktb_community_server/post/dto/PostDetailWithLikeInfoDto.java
@@ -1,0 +1,22 @@
+package com.ktb.howard.ktb_community_server.post.dto;
+
+import com.querydsl.core.annotations.QueryProjection;
+
+import java.time.LocalDateTime;
+
+public record PostDetailWithLikeInfoDto(
+        Long postId,
+        String title,
+        String content,
+        Integer likeCount,
+        Long viewCount,
+        Long commentCount,
+        Boolean isLiked,
+        Integer writerId,
+        String writerEmail,
+        String writerNickname,
+        LocalDateTime createdAt
+) {
+    @QueryProjection
+    public PostDetailWithLikeInfoDto { }
+}

--- a/src/main/java/com/ktb/howard/ktb_community_server/post/repository/PostQueryRepository.java
+++ b/src/main/java/com/ktb/howard/ktb_community_server/post/repository/PostQueryRepository.java
@@ -1,0 +1,43 @@
+package com.ktb.howard.ktb_community_server.post.repository;
+
+import com.ktb.howard.ktb_community_server.post.dto.PostDetailWithLikeInfoDto;
+import com.ktb.howard.ktb_community_server.post.dto.QPostDetailWithLikeInfoDto;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.AllArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+import static com.ktb.howard.ktb_community_server.post.domain.QPost.post;
+import static com.ktb.howard.ktb_community_server.post_like.domain.QPostLike.postLike;
+
+@AllArgsConstructor
+@Repository
+public class PostQueryRepository {
+
+    private final JPAQueryFactory queryFactory;
+
+    public Optional<PostDetailWithLikeInfoDto> getPostDetail(Long postId, Integer memberId) {
+        PostDetailWithLikeInfoDto postDetail = queryFactory
+                .select(new QPostDetailWithLikeInfoDto(
+                        post.id,
+                        post.title,
+                        post.content,
+                        post.likeCount,
+                        post.viewCount,
+                        post.commentCount,
+                        postLike.isNotNull(),
+                        post.writer.id,
+                        post.writer.email,
+                        post.writer.nickname,
+                        post.createdAt
+                ))
+                .from(post)
+                .leftJoin(postLike)
+                    .on(post.id.eq(postLike.post.id).and(postLike.member.id.eq(memberId)))
+                .where(post.id.eq(postId))
+                .fetchFirst();
+        return Optional.ofNullable(postDetail);
+    }
+
+}

--- a/src/test/java/com/ktb/howard/ktb_community_server/post/service/PostServiceTest.java
+++ b/src/test/java/com/ktb/howard/ktb_community_server/post/service/PostServiceTest.java
@@ -12,6 +12,7 @@ import com.ktb.howard.ktb_community_server.post.domain.Post;
 import com.ktb.howard.ktb_community_server.post.dto.CreatePostResponseDto;
 import com.ktb.howard.ktb_community_server.post.dto.GetPostsResponseDto;
 import com.ktb.howard.ktb_community_server.post.dto.PostDetailDto;
+import com.ktb.howard.ktb_community_server.post.exception.PostNotFoundException;
 import com.ktb.howard.ktb_community_server.post.repository.PostRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -22,6 +23,7 @@ import org.springframework.security.access.AccessDeniedException;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
+import java.time.temporal.ChronoUnit;
 import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.Optional;
@@ -311,7 +313,7 @@ class PostServiceTest {
         assertThat(response.getLikeCount()).isZero();
         assertThat(response.getViewCount()).isOne();
         assertThat(response.getCommentCount()).isZero();
-        assertThat(response.getCreatedAt()).isEqualTo(post.getCreatedAt());
+        assertThat(response.getCreatedAt()).isEqualTo(post.getCreatedAt().truncatedTo(ChronoUnit.SECONDS));
         assertThat(response.getWriter())
                 .extracting("email", "nickname", "profileImageUrl")
                 .containsExactly(writer.getEmail(), writer.getNickname(), null);
@@ -325,7 +327,7 @@ class PostServiceTest {
 
         // when // then
         assertThatThrownBy(() -> postService.getPostDetail(1L, 1))
-                .isInstanceOf(NoSuchElementException.class)
+                .isInstanceOf(PostNotFoundException.class)
                 .hasMessage("존재하지 않는 게시글입니다.");
     }
 


### PR DESCRIPTION
반영 완료. createdAt의 TimeStamp 정밀도 관련 이슈가 테스트 코드에서 발견됨. 간헐적으로 나타나는 현상이라 별도 이슈를 할당하여 해당 문제는 해결하기로 결정.