### PR TITLE
fix[#111]: 회원정보 수정 후 로그아웃 후 재로그인 전까지는 회원 닉네임이 계속 이전정보로 조회되는 현상 수정

### DIFF
--- a/src/main/java/com/ktb/howard/ktb_community_server/auth/dto/CustomUser.java
+++ b/src/main/java/com/ktb/howard/ktb_community_server/auth/dto/CustomUser.java
@@ -5,9 +5,12 @@ import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.userdetails.User;
 
 import java.util.Collection;
+import java.util.Objects;
 
 @Getter
 public class CustomUser extends User {
+
+    private static final long serialVersionUID = 1L;
 
     private final Integer id;
 
@@ -25,6 +28,39 @@ public class CustomUser extends User {
         this.id = id;
         this.email = email;
         this.nickname = nickname;
+    }
+
+    /**
+     * Spring Session이 Principal 객체의 변경을 감지할 수 있도록
+     * 부모 클래스(User)의 'username' 비교를 넘어 'id'와 'nickname'까지 비교합니다.
+     */
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        // 1. 부모 클래스(User)의 equals -> username 비교
+        if (!super.equals(obj)) {
+            return false;
+        }
+        // 2. 클래스 타입 확인
+        if (getClass() != obj.getClass()) {
+            return false;
+        }
+        // 3. 나머지 필드(id, email, nickname) 비교
+        CustomUser other = (CustomUser) obj;
+        return Objects.equals(id, other.id) &&
+                Objects.equals(email, other.email) &&
+                Objects.equals(nickname, other.nickname);
+    }
+
+    /**
+     * equals를 오버라이드했으므로 hashCode도 반드시 오버라이드합니다.
+     */
+    @Override
+    public int hashCode() {
+        // 부모 클래스의 hashCode(username 기준)와 나머지 필드를 조합
+        return Objects.hash(super.hashCode(), id, email, nickname);
     }
 
 }

--- a/src/main/java/com/ktb/howard/ktb_community_server/comment/service/CommentService.java
+++ b/src/main/java/com/ktb/howard/ktb_community_server/comment/service/CommentService.java
@@ -77,7 +77,7 @@ public class CommentService {
         return comments.stream()
                 .map(c -> {
                     MemberInfoResponseDto profile = memberService
-                            .getProfile(c.getMember().getId(), c.getMember().getEmail(), c.getMember().getNickname());
+                            .getProfile(c.getMember().getId());
                     return new CommentResponseDto(
                             c,
                             profile.imageId(),

--- a/src/main/java/com/ktb/howard/ktb_community_server/member/controller/MemberController.java
+++ b/src/main/java/com/ktb/howard/ktb_community_server/member/controller/MemberController.java
@@ -1,9 +1,12 @@
 package com.ktb.howard.ktb_community_server.member.controller;
 
 import com.ktb.howard.ktb_community_server.auth.dto.CustomUser;
+import com.ktb.howard.ktb_community_server.member.domain.Member;
 import com.ktb.howard.ktb_community_server.member.dto.MemberCreateRequestDto;
 import com.ktb.howard.ktb_community_server.member.dto.MemberInfoResponseDto;
 import com.ktb.howard.ktb_community_server.member.dto.MemberUpdateRequestDto;
+import com.ktb.howard.ktb_community_server.member.exception.MemberNotFoundException;
+import com.ktb.howard.ktb_community_server.member.repository.MemberRepository;
 import com.ktb.howard.ktb_community_server.member.service.MemberService;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.Email;
@@ -11,7 +14,10 @@ import jakarta.validation.constraints.Pattern;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
@@ -53,11 +59,7 @@ public class MemberController {
     @PreAuthorize("isAuthenticated()")
     @GetMapping("/me")
     public ResponseEntity<MemberInfoResponseDto> getMyProfile(@AuthenticationPrincipal CustomUser loginMember) {
-        MemberInfoResponseDto response = memberService.getProfile(
-                loginMember.getId(),
-                loginMember.getEmail(),
-                loginMember.getNickname()
-        );
+        MemberInfoResponseDto response = memberService.getProfile(loginMember.getId());
         return ResponseEntity.status(200).body(response);
     }
 
@@ -65,7 +67,8 @@ public class MemberController {
     @PatchMapping("/me")
     public ResponseEntity<String> updateMember(
             @AuthenticationPrincipal CustomUser loginMember,
-            @RequestBody MemberUpdateRequestDto request
+            @RequestBody MemberUpdateRequestDto request,
+            Authentication authentication
     ) {
         memberService.updateMember(
                 loginMember.getId(),
@@ -75,6 +78,30 @@ public class MemberController {
                 request.getProfileImageId(),
                 request.getDeleteProfileImage()
         );
+        // 3. DB에서 방금 수정된 최신 사용자 정보(Member 엔티티)를 다시 조회
+        Member updatedMember = memberService.findMemberById(loginMember.getId().longValue())
+                .orElseThrow(() -> new MemberNotFoundException("회원 정보를 찾을 수 없습니다."));
+
+        // 4. 최신 DB 정보(updatedMember)로 새로운 Principal(CustomUser) 객체를 생성
+        CustomUser newPrincipal = new CustomUser(
+                updatedMember.getEmail(),           // username (CustomUser의 username 필드, 이메일로 가정)
+                updatedMember.getPassword(),      // password (DB에 저장된 해시된 비밀번호)
+                authentication.getAuthorities(),  // authorities (기존 권한)
+                updatedMember.getId().intValue(), // id
+                updatedMember.getEmail(),           // email
+                updatedMember.getNickname()       // (닉네임 "B"가 담긴) 새 닉네임
+        );
+
+        // 5. 새 Principal로 새로운 Authentication 토큰을 생성합니다.
+        Authentication newAuth = new UsernamePasswordAuthenticationToken(
+                newPrincipal,                  // 새 정보가 담긴 Principal
+                null,                          // Credentials(비밀번호)는 갱신 시 null로 설정
+                newPrincipal.getAuthorities()  // 새 Principal의 권한
+        );
+
+        // 6. SecurityContextHolder에 새로운 인증 토큰을 설정합니다.
+        //    (이 코드가 실행되면 spring-session-jdbc가 세션 DB를 갱신합니다)
+        SecurityContextHolder.getContext().setAuthentication(newAuth);
         return ResponseEntity.ok("회원 정보가 수정되었습니다.");
     }
 

--- a/src/main/java/com/ktb/howard/ktb_community_server/member/service/MemberService.java
+++ b/src/main/java/com/ktb/howard/ktb_community_server/member/service/MemberService.java
@@ -20,6 +20,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.Optional;
 
 @Slf4j
 @RequiredArgsConstructor
@@ -51,6 +52,11 @@ public class MemberService {
     }
 
     @Transactional(readOnly = true)
+    public Optional<Member> findMemberById(Long memberId) {
+        return memberRepository.findById(memberId);
+    }
+
+    @Transactional(readOnly = true)
     public void checkEmail(String email) {
         if (memberRepository.existsByEmail(email)) {
             throw new AlreadyUsedEmailException("이미 가입에 사용된 이메일 입니다.", email);
@@ -65,11 +71,13 @@ public class MemberService {
     }
 
     @Transactional(readOnly = true)
-    public MemberInfoResponseDto getProfile(Integer memberId, String email, String nickname) {
+    public MemberInfoResponseDto getProfile(Integer memberId) {
         CreateImageViewUrlRequestDto request = new CreateImageViewUrlRequestDto(
                 ImageType.PROFILE,
                 memberId.longValue()
         );
+        Member member = memberRepository.findById(memberId.longValue())
+                .orElseThrow(() -> new MemberNotFoundException("존재하지 않는 회원입니다."));
         String profileImageUrl = null;
         Long imageId = null;
         List<ImageUrlResponseDto> response = imageService.createImageViewUrl(request);
@@ -77,7 +85,7 @@ public class MemberService {
             imageId = response.getFirst().imageId();
             profileImageUrl = response.getFirst().url();
         }
-        return new MemberInfoResponseDto(email, nickname, imageId, profileImageUrl);
+        return new MemberInfoResponseDto(member.getEmail(), member.getNickname(), imageId, profileImageUrl);
     }
 
     @Transactional

--- a/src/main/java/com/ktb/howard/ktb_community_server/post/service/PostService.java
+++ b/src/main/java/com/ktb/howard/ktb_community_server/post/service/PostService.java
@@ -96,7 +96,7 @@ public class PostService {
         return posts.stream()
                 .map(p -> {
                     MemberInfoResponseDto profile = memberService
-                            .getProfile(p.getWriter().getId(), p.getWriter().getEmail(), p.getWriter().getNickname());
+                            .getProfile(p.getWriter().getId());
                     return new GetPostsResponseDto(
                             p.getId(),
                             p.getTitle(),
@@ -116,11 +116,7 @@ public class PostService {
                     log.error("찾을 수 없는 게시글 = {}", postId);
                     return new PostNotFoundException("존재하지 않는 게시글입니다.");
                 });
-        MemberInfoResponseDto profile = memberService.getProfile(
-                postDetail.writerId(),
-                postDetail.writerEmail(),
-                postDetail.writerNickname()
-        );
+        MemberInfoResponseDto profile = memberService.getProfile(postDetail.writerId());
         List<PostImageInfoDto> postImages = imageService.createImageViewUrl(new CreateImageViewUrlRequestDto(ImageType.POST, postId))
                 .stream()
                 .map(pi -> new PostImageInfoDto(pi.url(), pi.sequence(), pi.expiresAt()))


### PR DESCRIPTION
수정 완료. nickname의 값을 CustomUser의 값을 사용하면서 수정되지 않은 이전값이 전파되어 해당 문제가 발생하였다. 문제를 일으키는 해당 지점을 발견하였고, 관련 로직을 수정하여 문제가 해결된 것을 확인하였다. 잘못된 값의 전파를 경계하자. 변수 이름이 조금 길더라도 명확하게 지어서 사용하자.