### PR TITLE
fix[#117]: 게시글 이미지 수정로직 오류 수정

### DIFF
--- a/src/main/java/com/ktb/howard/ktb_community_server/image/service/ImageService.java
+++ b/src/main/java/com/ktb/howard/ktb_community_server/image/service/ImageService.java
@@ -123,7 +123,7 @@ public class ImageService {
     }
 
     @Transactional
-    public void persistImage(Long imageId, Member owner, Long referenceId) {
+    public void persistImage(Long imageId, Member owner, Long referenceId, Integer sequence) {
         Optional<Image> imageOpt = imageRepository.findById(imageId);
         if (imageOpt.isEmpty()) {
             log.error("존재하지 않은 이미지: imageId={}, ownerId={}, referenceId={}", imageId, owner.getId(), referenceId);
@@ -140,6 +140,7 @@ public class ImageService {
         image.updateReference(referenceId);
         image.updateObjectKey(persistObjectKey.objectKey());
         image.updateStatus(ImageStatus.PERSIST);
+        image.updateSequence(sequence);
     }
 
     @Transactional

--- a/src/main/java/com/ktb/howard/ktb_community_server/member/service/MemberService.java
+++ b/src/main/java/com/ktb/howard/ktb_community_server/member/service/MemberService.java
@@ -46,7 +46,7 @@ public class MemberService {
                 log.error("이미지 {}가 존재하지 않습니다.", request.getProfileImageId());
                 throw new IllegalStateException(String.format("이미지 %d가 존재하지 않습니다.", request.getProfileImageId()));
             }
-            imageService.persistImage(request.getProfileImageId(), member, member.getId().longValue());
+            imageService.persistImage(request.getProfileImageId(), member, member.getId().longValue(), 1);
         }
         return member;
     }
@@ -132,7 +132,7 @@ public class MemberService {
         // 4-2. 새롭게 업로드한 이미지가 있는 경우 영속화 진행
         if (profileImageId != null) {
             log.info("새로운 프로필 이미지 영속화 : imageId={}, memberId={}", profileImageId, memberId);
-            imageService.persistImage(profileImageId, member, member.getId().longValue());
+            imageService.persistImage(profileImageId, member, member.getId().longValue(), 1);
         }
     }
 

--- a/src/main/java/com/ktb/howard/ktb_community_server/post/service/PostService.java
+++ b/src/main/java/com/ktb/howard/ktb_community_server/post/service/PostService.java
@@ -6,7 +6,6 @@ import com.ktb.howard.ktb_community_server.cache.repository.ViewCountCacheReposi
 import com.ktb.howard.ktb_community_server.image.domain.Image;
 import com.ktb.howard.ktb_community_server.image.domain.ImageType;
 import com.ktb.howard.ktb_community_server.image.dto.CreateImageViewUrlRequestDto;
-import com.ktb.howard.ktb_community_server.image.dto.ImageUrlResponseDto;
 import com.ktb.howard.ktb_community_server.image.service.ImageService;
 import com.ktb.howard.ktb_community_server.like_log.domain.LikeLogType;
 import com.ktb.howard.ktb_community_server.like_log.service.LikeLogService;
@@ -71,7 +70,7 @@ public class PostService {
                     log.error("이미지 {}가 존재하지 않습니다.", i.imageId());
                     throw new IllegalStateException(String.format("이미지 %d가 존재하지 않습니다.", i.imageId()));
                 }
-                imageService.persistImage(i.imageId(), writer, post.getId());
+                imageService.persistImage(i.imageId(), writer, post.getId(), i.sequence());
             });
         }
 
@@ -206,7 +205,7 @@ public class PostService {
                     }
                 } else {
                     // 추가 대상: 이미지를 영속화하고 게시글과 연결
-                    imageService.persistImage(imageId, post.getWriter(), loginMemberId.longValue());
+                    imageService.persistImage(imageId, post.getWriter(), postId, requestImage.sequence());
                 }
             }
         }


### PR DESCRIPTION
수정 완료. 수정로직에서 이미지를 영속화 하는 과정 중 referenceId를 잘못된 값으로 넘기고 있음을 확인함.
DB의 제약조건을 적용할 수 없는 형성관계이다보니 이런 단점이 있는 것 같다. 이 문제를 보완할 수 있는 방법에 대해서는 조금 더 고민해보자